### PR TITLE
Add CORs support

### DIFF
--- a/functions/adoption/libs/utils.py
+++ b/functions/adoption/libs/utils.py
@@ -1,9 +1,9 @@
 import json
 
-def output(result):
+def output(result, headers={}):
   status = 200 if result.success() else 400
   payload = result.result if result.success() else convert_to_hashes(result.errors)
-  return (json.dumps(payload), status)
+  return (json.dumps(payload), status, headers)
 
 def convert_to_hashes(arr):
     hashes_arr = []

--- a/functions/adoption/main.py
+++ b/functions/adoption/main.py
@@ -5,6 +5,24 @@ from .libs.queries import list_data
 
 @functions_framework.http
 def dispatcher(request):
+  # For more information about CORS and CORS preflight requests, see:
+  # https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request
+
+  # Set CORS headers for the preflight request
+  if request.method == "OPTIONS":
+      # Allows GET requests from any origin with the Content-Type
+      # header and caches preflight response for an 3600s
+      headers = {
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Methods": "GET",
+          "Access-Control-Allow-Headers": "Content-Type",
+          "Access-Control-Max-Age": "3600",
+      }
+
+      return ("", 204, headers)
+
+  # Set CORS headers for the main request
+  headers = {"Access-Control-Allow-Origin": "*"}
   args = request.args.to_dict()
 
   validator = Validator(params=args)
@@ -16,4 +34,4 @@ def dispatcher(request):
   
   response = list_data(result.result)
 
-  return output(response)
+ return output(response, headers)

--- a/functions/categories/libs/utils.py
+++ b/functions/categories/libs/utils.py
@@ -1,9 +1,9 @@
 import json
 
-def output(result):
+def output(result, headers={}):
   status = 200 if result.success() else 400
   payload = result.result if result.success() else convert_to_hashes(result.errors)
-  return (json.dumps(payload), status)
+  return (json.dumps(payload), status, headers)
 
 def convert_to_hashes(arr):
     hashes_arr = []

--- a/functions/categories/main.py
+++ b/functions/categories/main.py
@@ -5,6 +5,24 @@ from .libs.queries import list_data
 
 @functions_framework.http
 def dispatcher(request):
+  # For more information about CORS and CORS preflight requests, see:
+  # https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request
+
+  # Set CORS headers for the preflight request
+  if request.method == "OPTIONS":
+      # Allows GET requests from any origin with the Content-Type
+      # header and caches preflight response for an 3600s
+      headers = {
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Methods": "GET",
+          "Access-Control-Allow-Headers": "Content-Type",
+          "Access-Control-Max-Age": "3600",
+      }
+
+      return ("", 204, headers)
+
+  # Set CORS headers for the main request
+  headers = {"Access-Control-Allow-Origin": "*"}
   args = request.args.to_dict()
 
   validator = Validator(params=args)
@@ -16,4 +34,4 @@ def dispatcher(request):
   
   response = list_data(result.result)
 
-  return output(response)
+ return output(response, headers)

--- a/functions/cwvtech/libs/utils.py
+++ b/functions/cwvtech/libs/utils.py
@@ -1,9 +1,9 @@
 import json
 
-def output(result):
+def output(result, headers={}):
   status = 200 if result.success() else 400
   payload = result.result if result.success() else convert_to_hashes(result.errors)
-  return (json.dumps(payload), status)
+  return (json.dumps(payload), status, headers)
 
 def convert_to_hashes(arr):
     hashes_arr = []

--- a/functions/cwvtech/main.py
+++ b/functions/cwvtech/main.py
@@ -5,6 +5,24 @@ from .libs.queries import list_data
 
 @functions_framework.http
 def dispatcher(request):
+  # For more information about CORS and CORS preflight requests, see:
+  # https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request
+
+  # Set CORS headers for the preflight request
+  if request.method == "OPTIONS":
+      # Allows GET requests from any origin with the Content-Type
+      # header and caches preflight response for an 3600s
+      headers = {
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Methods": "GET",
+          "Access-Control-Allow-Headers": "Content-Type",
+          "Access-Control-Max-Age": "3600",
+      }
+
+      return ("", 204, headers)
+
+  # Set CORS headers for the main request
+  headers = {"Access-Control-Allow-Origin": "*"}
   args = request.args.to_dict()
 
   validator = Validator(params=args)
@@ -16,4 +34,4 @@ def dispatcher(request):
   
   response = list_data(result.result)
 
-  return output(response)
+ return output(response, headers)

--- a/functions/geos/libs/utils.py
+++ b/functions/geos/libs/utils.py
@@ -1,9 +1,9 @@
 import json
 
-def output(result):
+def output(result, headers={}):
   status = 200 if result.success() else 400
   payload = result.result if result.success() else convert_to_hashes(result.errors)
-  return (json.dumps(payload), status)
+  return (json.dumps(payload), status, headers)
 
 def convert_to_hashes(arr):
     hashes_arr = []

--- a/functions/geos/main.py
+++ b/functions/geos/main.py
@@ -6,7 +6,25 @@ from .libs.result import Result
 
 @functions_framework.http
 def dispatcher(request):
+  # For more information about CORS and CORS preflight requests, see:
+  # https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request
+
+  # Set CORS headers for the preflight request
+  if request.method == "OPTIONS":
+      # Allows GET requests from any origin with the Content-Type
+      # header and caches preflight response for an 3600s
+      headers = {
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Methods": "GET",
+          "Access-Control-Allow-Headers": "Content-Type",
+          "Access-Control-Max-Age": "3600",
+      }
+
+      return ("", 204, headers)
+
+  # Set CORS headers for the main request
+  headers = {"Access-Control-Allow-Origin": "*"}
   
   response = Result(result=COUNTRIES)
 
-  return output(response)
+ return output(response, headers)

--- a/functions/lighthouse/libs/utils.py
+++ b/functions/lighthouse/libs/utils.py
@@ -1,9 +1,9 @@
 import json
 
-def output(result):
+def output(result, headers={}):
   status = 200 if result.success() else 400
   payload = result.result if result.success() else convert_to_hashes(result.errors)
-  return (json.dumps(payload), status)
+  return (json.dumps(payload), status, headers)
 
 def convert_to_hashes(arr):
     hashes_arr = []

--- a/functions/lighthouse/main.py
+++ b/functions/lighthouse/main.py
@@ -5,6 +5,24 @@ from .libs.queries import list_data
 
 @functions_framework.http
 def dispatcher(request):
+  # For more information about CORS and CORS preflight requests, see:
+  # https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request
+
+  # Set CORS headers for the preflight request
+  if request.method == "OPTIONS":
+      # Allows GET requests from any origin with the Content-Type
+      # header and caches preflight response for an 3600s
+      headers = {
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Methods": "GET",
+          "Access-Control-Allow-Headers": "Content-Type",
+          "Access-Control-Max-Age": "3600",
+      }
+
+      return ("", 204, headers)
+
+  # Set CORS headers for the main request
+  headers = {"Access-Control-Allow-Origin": "*"}
   args = request.args.to_dict()
 
   validator = Validator(params=args)
@@ -16,4 +34,4 @@ def dispatcher(request):
   
   response = list_data(result.result)
 
-  return output(response)
+ return output(response, headers)

--- a/functions/ranks/libs/utils.py
+++ b/functions/ranks/libs/utils.py
@@ -1,9 +1,9 @@
 import json
 
-def output(result):
+def output(result, headers={}):
   status = 200 if result.success() else 400
   payload = result.result if result.success() else convert_to_hashes(result.errors)
-  return (json.dumps(payload), status)
+  return (json.dumps(payload), status, headers)
 
 def convert_to_hashes(arr):
     hashes_arr = []

--- a/functions/ranks/main.py
+++ b/functions/ranks/main.py
@@ -6,7 +6,25 @@ from .libs.result import Result
 
 @functions_framework.http
 def dispatcher(request):
+  # For more information about CORS and CORS preflight requests, see:
+  # https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request
+
+  # Set CORS headers for the preflight request
+  if request.method == "OPTIONS":
+      # Allows GET requests from any origin with the Content-Type
+      # header and caches preflight response for an 3600s
+      headers = {
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Methods": "GET",
+          "Access-Control-Allow-Headers": "Content-Type",
+          "Access-Control-Max-Age": "3600",
+      }
+
+      return ("", 204, headers)
+
+  # Set CORS headers for the main request
+  headers = {"Access-Control-Allow-Origin": "*"}
   
   response = Result(result=RANKS)
 
-  return output(response)
+ return output(response, headers)

--- a/functions/report/libs/utils.py
+++ b/functions/report/libs/utils.py
@@ -1,9 +1,9 @@
 import json
 
-def output(result):
+def output(result, headers={}):
   status = 200 if result.success() else 400
   payload = result.result if result.success() else convert_to_hashes(result.errors)
-  return (json.dumps(payload), status)
+  return (json.dumps(payload), status, headers)
 
 def convert_to_hashes(arr):
     hashes_arr = []

--- a/functions/report/main.py
+++ b/functions/report/main.py
@@ -5,6 +5,24 @@ from .libs.queries import list_data
 
 @functions_framework.http
 def dispatcher(request):
+  # For more information about CORS and CORS preflight requests, see:
+  # https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request
+
+  # Set CORS headers for the preflight request
+  if request.method == "OPTIONS":
+      # Allows GET requests from any origin with the Content-Type
+      # header and caches preflight response for an 3600s
+      headers = {
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Methods": "GET",
+          "Access-Control-Allow-Headers": "Content-Type",
+          "Access-Control-Max-Age": "3600",
+      }
+
+      return ("", 204, headers)
+
+  # Set CORS headers for the main request
+  headers = {"Access-Control-Allow-Origin": "*"}
   args = request.args.to_dict()
 
   validator = Validator(params=args)
@@ -16,4 +34,4 @@ def dispatcher(request):
   
   response = list_data(result.result)
 
-  return output(response)
+ return output(response, headers)

--- a/functions/technologies/libs/utils.py
+++ b/functions/technologies/libs/utils.py
@@ -1,9 +1,9 @@
 import json
 
-def output(result):
+def output(result, headers={}):
   status = 200 if result.success() else 400
   payload = result.result if result.success() else convert_to_hashes(result.errors)
-  return (json.dumps(payload), status)
+  return (json.dumps(payload), status, headers)
 
 def convert_to_hashes(arr):
     hashes_arr = []

--- a/functions/technologies/main.py
+++ b/functions/technologies/main.py
@@ -5,6 +5,24 @@ from .libs.queries import list_data
 
 @functions_framework.http
 def dispatcher(request):
+  # For more information about CORS and CORS preflight requests, see:
+  # https://developer.mozilla.org/en-US/docs/Glossary/Preflight_request
+
+  # Set CORS headers for the preflight request
+  if request.method == "OPTIONS":
+      # Allows GET requests from any origin with the Content-Type
+      # header and caches preflight response for an 3600s
+      headers = {
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Methods": "GET",
+          "Access-Control-Allow-Headers": "Content-Type",
+          "Access-Control-Max-Age": "3600",
+      }
+
+      return ("", 204, headers)
+
+  # Set CORS headers for the main request
+  headers = {"Access-Control-Allow-Origin": "*"}
   args = request.args.to_dict()
 
   validator = Validator(params=args)
@@ -16,4 +34,4 @@ def dispatcher(request):
   
   response = list_data(result.result)
 
-  return output(response)
+ return output(response, headers)


### PR DESCRIPTION
I'm sure there's a better way to do this, but here's what I did to unblock Sarah.

@rviscomi not sure if we want to restrict these calls to certain domains? CORS is more a browser protection than a real security protection if we're concerned about rate limit these and the data is read-only from the API calls to happy to have them open from a CORs perspective.

@maceto, feel free to re-code this in a better way!