### PR TITLE
🔒 fix: prevent sensitive information disclosure in cdnController error response

### DIFF
--- a/apps/report-api/controllers/cdnController.js
+++ b/apps/report-api/controllers/cdnController.js
@@ -118,8 +118,7 @@ export const proxyReportsFile = async (req, res, filePath) => {
         if (!res.headersSent) {
             res.statusCode = 500;
             res.end(JSON.stringify({
-                error: 'Server failed to respond',
-                details: error.message
+                error: 'Server failed to respond'
             }));
         }
     }

--- a/apps/report-api/tests/routes.test.js
+++ b/apps/report-api/tests/routes.test.js
@@ -759,7 +759,6 @@ describe('API Routes', () => {
           .expect(500);
 
         expect(res.body).toHaveProperty('error', 'Server failed to respond');
-        expect(res.body).toHaveProperty('details');
       });
 
       it('should handle GCS getMetadata() failure', async () => {
@@ -771,7 +770,6 @@ describe('API Routes', () => {
           .expect(500);
 
         expect(res.body).toHaveProperty('error', 'Server failed to respond');
-        expect(res.body).toHaveProperty('details');
       });
 
       it('should handle stream errors during file read', async () => {


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
In `apps/report-api/controllers/cdnController.js`, internal server errors that occurred during Google Cloud Storage proxying (like stream read errors) were caught and their internal `error.message` details were sent directly to the client in an HTTP 500 JSON response payload (`details: error.message`). 

⚠️ **Risk:** The potential impact if left unfixed
Exposing internal error messages to clients can leak sensitive backend architecture information, internal file paths, module versions, or database configuration states. Attackers can leverage this information disclosure to plan more sophisticated and targeted exploits against the system.

🛡️ **Solution:** How the fix addresses the vulnerability
The `details` property containing `error.message` was removed from the client-facing error payload. The proxy endpoint now returns a generic "Server failed to respond" message. Internal error details are still preserved for administrators by logging them securely to the server console via the existing `console.error` call. Unit tests in `routes.test.js` were updated to assert against this secure, generic response structure.

---
*PR created automatically by Jules for task [18427194880631561151](https://jules.google.com/task/18427194880631561151) started by @max-ostapenko*